### PR TITLE
No output needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Visualize the structure of Xml documents easily, with human readable output (gre
 
 Usage:
 
-    XmlToBullet.exe <inputpath> <outputpath>
+    XmlToBullet.exe <inputpath> [<outputpath>]
 
 Options:
 

--- a/XmlToBullet.Tests/AppArgumentTests.cs
+++ b/XmlToBullet.Tests/AppArgumentTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+
+namespace XmlToBullet.Tests
+{
+    [TestFixture]
+    public sealed class AppArgumentTests
+    {
+        [Test]
+        public void Empty_should_show_help()
+        {
+            AppArguments args = AppArguments.From(new string[0]);
+            Assert.IsTrue(args.ShowHelp);
+        }
+
+        [Test]
+        public void Two_arguments_defaults()
+        {
+            AppArguments args = AppArguments.From(new[] {"In.xml", "out.txt"});
+            Assert.IsFalse(args.ShowHelp);
+            Assert.AreEqual("In.xml", args.InPath);
+            Assert.AreEqual("out.txt", args.OutPath);
+            Assert.IsTrue(args.ShowAttributes);
+            Assert.AreEqual("+", args.AttibuteBullet);
+        }
+
+        [Test]
+        public void Disable_attributes()
+        {
+            AppArguments args = AppArguments.From(new[] {"In.xml", "out.txt", "-noAttributes"});
+            Assert.IsFalse(args.ShowAttributes);
+            Assert.IsNull(args.AttibuteBullet);
+        }
+
+        [Test]
+        public void Specify_bullet()
+        {
+            AppArguments args = AppArguments.From(new[] {"In.xml", "out.txt", "-a=#"});
+            Assert.IsTrue(args.ShowAttributes);
+            Assert.AreEqual("#", args.AttibuteBullet);
+        }
+    }
+}

--- a/XmlToBullet.Tests/AppArgumentTests.cs
+++ b/XmlToBullet.Tests/AppArgumentTests.cs
@@ -5,10 +5,13 @@ namespace XmlToBullet.Tests
     [TestFixture]
     public sealed class AppArgumentTests
     {
-        [Test]
-        public void Empty_should_show_help()
+        [TestCase("")]
+        [TestCase("-a=# -noAttribute")]
+        [TestCase("In.xml out.txt -help")]
+        [TestCase("In.xml out.txt thirdarg")]
+        public void Should_show_help(string commandLine)
         {
-            AppArguments args = AppArguments.From(new string[0]);
+            AppArguments args = AppArguments.From(commandLine.Split(' '));
             Assert.IsTrue(args.ShowHelp);
         }
 
@@ -23,7 +26,20 @@ namespace XmlToBullet.Tests
             Assert.AreEqual("+", args.AttibuteBullet);
         }
 
+        [TestCase("In.xml out.txt")]
+        [TestCase("In.xml out.txt -a=#")]
+        [TestCase("-a# In.xml out.txt")]
+        [TestCase("In.xml -a=# out.txt")]
+        public void Paths(string commandLine)
+        {
+            AppArguments args = AppArguments.From(commandLine.Split(' '));
+            Assert.AreEqual("In.xml", args.InPath);
+            Assert.AreEqual("out.txt", args.OutPath);
+        }
+
         [TestCase("In.xml out.txt -noAttributes")]
+        [TestCase("-noAttributes In.xml out.txt")]
+        [TestCase("In.xml -noAttributes out.txt")]
         public void Disable_attributes(string commandLine)
         {
             AppArguments args = AppArguments.From(commandLine.Split(' '));
@@ -32,6 +48,8 @@ namespace XmlToBullet.Tests
         }
 
         [TestCase("In.xml out.txt -a=#")]
+        [TestCase("-a=# In.xml out.txt")]
+        [TestCase("In.xml -a=# out.txt")]
         public void Specify_bullet(string commandLine)
         {
             AppArguments args = AppArguments.From(commandLine.Split(' '));

--- a/XmlToBullet.Tests/AppArgumentTests.cs
+++ b/XmlToBullet.Tests/AppArgumentTests.cs
@@ -12,10 +12,10 @@ namespace XmlToBullet.Tests
             Assert.IsTrue(args.ShowHelp);
         }
 
-        [Test]
-        public void Two_arguments_defaults()
+        [TestCase("In.xml out.txt")]
+        public void Two_arguments_defaults(string commandLine)
         {
-            AppArguments args = AppArguments.From(new[] {"In.xml", "out.txt"});
+            AppArguments args = AppArguments.From(commandLine.Split(' '));
             Assert.IsFalse(args.ShowHelp);
             Assert.AreEqual("In.xml", args.InPath);
             Assert.AreEqual("out.txt", args.OutPath);
@@ -23,18 +23,18 @@ namespace XmlToBullet.Tests
             Assert.AreEqual("+", args.AttibuteBullet);
         }
 
-        [Test]
-        public void Disable_attributes()
+        [TestCase("In.xml out.txt -noAttributes")]
+        public void Disable_attributes(string commandLine)
         {
-            AppArguments args = AppArguments.From(new[] {"In.xml", "out.txt", "-noAttributes"});
+            AppArguments args = AppArguments.From(commandLine.Split(' '));
             Assert.IsFalse(args.ShowAttributes);
             Assert.IsNull(args.AttibuteBullet);
         }
 
-        [Test]
-        public void Specify_bullet()
+        [TestCase("In.xml out.txt -a=#")]
+        public void Specify_bullet(string commandLine)
         {
-            AppArguments args = AppArguments.From(new[] {"In.xml", "out.txt", "-a=#"});
+            AppArguments args = AppArguments.From(commandLine.Split(' '));
             Assert.IsTrue(args.ShowAttributes);
             Assert.AreEqual("#", args.AttibuteBullet);
         }

--- a/XmlToBullet.Tests/AppArgumentTests.cs
+++ b/XmlToBullet.Tests/AppArgumentTests.cs
@@ -29,7 +29,7 @@ namespace XmlToBullet.Tests
             Assert.AreEqual("In.xml", args.InPath);
             Assert.AreEqual("out.txt", args.OutPath);
             Assert.IsTrue(args.ShowAttributes);
-            Assert.AreEqual("+", args.AttibuteBullet);
+            Assert.AreEqual("+", args.AttributeBullet);
         }
 
         [TestCase("In.xml out.txt")]
@@ -50,7 +50,7 @@ namespace XmlToBullet.Tests
         {
             AppArguments args = AppArguments.From(Split(commandLine));
             Assert.IsFalse(args.ShowAttributes);
-            Assert.IsNull(args.AttibuteBullet);
+            Assert.IsNull(args.AttributeBullet);
         }
 
         [TestCase("In.xml out.txt -a=#")]
@@ -62,7 +62,7 @@ namespace XmlToBullet.Tests
         {
             AppArguments args = AppArguments.From(Split(commandLine));
             Assert.IsTrue(args.ShowAttributes);
-            Assert.AreEqual("#", args.AttibuteBullet);
+            Assert.AreEqual("#", args.AttributeBullet);
         }
 
         [TestCase("Input.xml")]

--- a/XmlToBullet.Tests/AppArgumentTests.cs
+++ b/XmlToBullet.Tests/AppArgumentTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 
 namespace XmlToBullet.Tests
 {
@@ -11,14 +12,19 @@ namespace XmlToBullet.Tests
         [TestCase("In.xml out.txt thirdarg")]
         public void Should_show_help(string commandLine)
         {
-            AppArguments args = AppArguments.From(commandLine.Split(' '));
+            AppArguments args = AppArguments.From(Split(commandLine));
             Assert.IsTrue(args.ShowHelp);
+        }
+
+        private static string[] Split(string commandLine)
+        {
+            return commandLine.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
         }
 
         [TestCase("In.xml out.txt")]
         public void Two_arguments_defaults(string commandLine)
         {
-            AppArguments args = AppArguments.From(commandLine.Split(' '));
+            AppArguments args = AppArguments.From(Split(commandLine));
             Assert.IsFalse(args.ShowHelp);
             Assert.AreEqual("In.xml", args.InPath);
             Assert.AreEqual("out.txt", args.OutPath);
@@ -32,7 +38,7 @@ namespace XmlToBullet.Tests
         [TestCase("In.xml -a=# out.txt")]
         public void Paths(string commandLine)
         {
-            AppArguments args = AppArguments.From(commandLine.Split(' '));
+            AppArguments args = AppArguments.From(Split(commandLine));
             Assert.AreEqual("In.xml", args.InPath);
             Assert.AreEqual("out.txt", args.OutPath);
         }
@@ -42,7 +48,7 @@ namespace XmlToBullet.Tests
         [TestCase("In.xml -noAttributes out.txt")]
         public void Disable_attributes(string commandLine)
         {
-            AppArguments args = AppArguments.From(commandLine.Split(' '));
+            AppArguments args = AppArguments.From(Split(commandLine));
             Assert.IsFalse(args.ShowAttributes);
             Assert.IsNull(args.AttibuteBullet);
         }
@@ -50,11 +56,25 @@ namespace XmlToBullet.Tests
         [TestCase("In.xml out.txt -a=#")]
         [TestCase("-a=# In.xml out.txt")]
         [TestCase("In.xml -a=# out.txt")]
+        [TestCase("In.xml -a=#")]
+        [TestCase("-a=# In.xml")]
         public void Specify_bullet(string commandLine)
         {
-            AppArguments args = AppArguments.From(commandLine.Split(' '));
+            AppArguments args = AppArguments.From(Split(commandLine));
             Assert.IsTrue(args.ShowAttributes);
             Assert.AreEqual("#", args.AttibuteBullet);
+        }
+
+        [TestCase("Input.xml")]
+        [TestCase("Input.xml -a=#")]
+        [TestCase("-a=# Input.xml")]
+        [TestCase("Input.xml -noAttribute")]
+        public void Only_input_specified(string commandLine)
+        {
+            AppArguments args = AppArguments.From(Split(commandLine));
+            Assert.IsFalse(args.ShowHelp);
+            Assert.AreEqual("Input.xml", args.InPath);
+            Assert.IsNull(args.OutPath);
         }
     }
 }

--- a/XmlToBullet.Tests/XmlToBullet.Tests.csproj
+++ b/XmlToBullet.Tests/XmlToBullet.Tests.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppArgumentTests.cs" />
     <Compile Include="ConvertTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/XmlToBullet/AppArguments.cs
+++ b/XmlToBullet/AppArguments.cs
@@ -11,19 +11,21 @@ namespace XmlToBullet
 
         public static AppArguments From(string[] args)
         {
-            var showHelp = args.Count() < 2 | args.Contains("-help");
+            var nonSwitches = args.Where(a => !a.StartsWith("-")).ToArray();
+            var switches = args.Where(a => a.StartsWith("-")).ToArray();
+
+            var showHelp = nonSwitches.Count() != 2 || args.Contains("-help");
 
             if (showHelp)
             {
                 return new AppArguments {ShowHelp = true};
             }
 
-            string filePath = args[0];
-            string fileOutPath = args[1];
-            var otherargs = args.Skip(2).ToArray();
+            string filePath = nonSwitches[0];
+            string fileOutPath = nonSwitches[1];
 
-            var noAttributesOption = otherargs.FirstOrDefault(a => a.StartsWith("-noAttributes"));
-            var attributeOption = otherargs.FirstOrDefault(a => a.StartsWith("-a="));
+            var noAttributesOption = switches.FirstOrDefault(a => a.StartsWith("-noAttributes"));
+            var attributeOption = switches.FirstOrDefault(a => a.StartsWith("-a="));
 
             var attibuteBullet = noAttributesOption != null
                 ? null

--- a/XmlToBullet/AppArguments.cs
+++ b/XmlToBullet/AppArguments.cs
@@ -24,7 +24,7 @@ namespace XmlToBullet
             var noAttributesOption = switches.FirstOrDefault(a => a.StartsWith("-noAttributes"));
             var attributeOption = switches.FirstOrDefault(a => a.StartsWith("-a="));
 
-            var attibuteBullet = noAttributesOption != null
+            var attributeBullet = noAttributesOption != null
                 ? null
                 : (String.IsNullOrEmpty(attributeOption) ? "+" : attributeOption.Substring(3));
 
@@ -34,7 +34,7 @@ namespace XmlToBullet
                 InPath = nonSwitches.First(),
                 OutPath = nonSwitches.Skip(1).FirstOrDefault(),
                 ShowAttributes = noAttributesOption == null,
-                AttibuteBullet = attibuteBullet
+                AttributeBullet = attributeBullet
             };
         }
 
@@ -42,6 +42,6 @@ namespace XmlToBullet
         public string InPath { get; private set; }
         public string OutPath { get; private set; }
         public bool ShowAttributes { get; private set; }
-        public string AttibuteBullet { get; private set; }
+        public string AttributeBullet { get; private set; }
     }
 }

--- a/XmlToBullet/AppArguments.cs
+++ b/XmlToBullet/AppArguments.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+
+namespace XmlToBullet
+{
+    public sealed class AppArguments
+    {
+        private AppArguments()
+        {
+        }
+
+        public static AppArguments From(string[] args)
+        {
+            var showHelp = args.Count() < 2 | args.Contains("-help");
+
+            if (showHelp)
+            {
+                return new AppArguments {ShowHelp = true};
+            }
+
+            string filePath = args[0];
+            string fileOutPath = args[1];
+            var otherargs = args.Skip(2).ToArray();
+
+            var noAttributesOption = otherargs.FirstOrDefault(a => a.StartsWith("-noAttributes"));
+            var attributeOption = otherargs.FirstOrDefault(a => a.StartsWith("-a="));
+
+            var attibuteBullet = noAttributesOption != null
+                ? null
+                : (String.IsNullOrEmpty(attributeOption) ? "+" : attributeOption.Substring(3));
+
+            return new AppArguments
+            {
+                ShowHelp = false,
+                InPath = filePath,
+                OutPath = fileOutPath,
+                ShowAttributes = noAttributesOption == null,
+                AttibuteBullet = attibuteBullet
+            };
+        }
+
+        public bool ShowHelp { get; private set; }
+        public string InPath { get; private set; }
+        public string OutPath { get; private set; }
+        public bool ShowAttributes { get; private set; }
+        public string AttibuteBullet { get; private set; }
+    }
+}

--- a/XmlToBullet/AppArguments.cs
+++ b/XmlToBullet/AppArguments.cs
@@ -14,15 +14,12 @@ namespace XmlToBullet
             var nonSwitches = args.Where(a => !a.StartsWith("-")).ToArray();
             var switches = args.Where(a => a.StartsWith("-")).ToArray();
 
-            var showHelp = nonSwitches.Count() != 2 || args.Contains("-help");
+            var showHelp = (nonSwitches.Length != 1 && nonSwitches.Length != 2) || args.Contains("-help");
 
             if (showHelp)
             {
                 return new AppArguments {ShowHelp = true};
             }
-
-            string filePath = nonSwitches[0];
-            string fileOutPath = nonSwitches[1];
 
             var noAttributesOption = switches.FirstOrDefault(a => a.StartsWith("-noAttributes"));
             var attributeOption = switches.FirstOrDefault(a => a.StartsWith("-a="));
@@ -34,8 +31,8 @@ namespace XmlToBullet
             return new AppArguments
             {
                 ShowHelp = false,
-                InPath = filePath,
-                OutPath = fileOutPath,
+                InPath = nonSwitches.First(),
+                OutPath = nonSwitches.Skip(1).FirstOrDefault(),
                 ShowAttributes = noAttributesOption == null,
                 AttibuteBullet = attibuteBullet
             };

--- a/XmlToBullet/ConsoleApp.cs
+++ b/XmlToBullet/ConsoleApp.cs
@@ -8,7 +8,7 @@ namespace XmlToBullet
         public static void Main(string[] args)
         {
             const string helptext = @"Usage:
-	XmlToBullet.exe <inputpath> <outputpath>
+	XmlToBullet.exe <inputpath> [<outputpath>]
 
 Options:
 	-a=<attribute bullet point symbol>      specify the bullet point used for attributes (default '+')
@@ -27,7 +27,14 @@ Options:
 
             var asBullets = new XmlConverter(appArgs.AttibuteBullet).Convert(text);
 
-            File.WriteAllText(appArgs.OutPath, asBullets);
+            if (appArgs.OutPath == null)
+            {
+                Console.WriteLine(asBullets);
+            }
+            else
+            {
+                File.WriteAllText(appArgs.OutPath, asBullets);
+            }
         }
     }
 }

--- a/XmlToBullet/ConsoleApp.cs
+++ b/XmlToBullet/ConsoleApp.cs
@@ -25,7 +25,7 @@ Options:
 
             var text = File.ReadAllText(appArgs.InPath);
 
-            var asBullets = new XmlConverter(appArgs.AttibuteBullet).Convert(text);
+            var asBullets = new XmlConverter(appArgs.AttributeBullet).Convert(text);
 
             if (appArgs.OutPath == null)
             {

--- a/XmlToBullet/ConsoleApp.cs
+++ b/XmlToBullet/ConsoleApp.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace XmlToBullet
 {
@@ -19,30 +15,19 @@ Options:
 	-noAttributes                           do not show attributes at all
 	-help                                   show helptext";
 
-            var showHelp = args.Count() < 2 | args.Contains("-help");
+            var appArgs = AppArguments.From(args);
 
-            if (showHelp)
+            if (appArgs.ShowHelp)
             {
                 Console.WriteLine(helptext);
                 return;
             }
 
+            var text = File.ReadAllText(appArgs.InPath);
 
-            string filePath = args[0];
-            string fileOutPath = args[1];
-            var otherargs = args.Skip(2).ToArray();
+            var asBullets = new XmlConverter(appArgs.AttibuteBullet).Convert(text);
 
-            var noAttributesOption = otherargs.FirstOrDefault(a => a.StartsWith("-noAttributes"));
-            var attributeOption = otherargs.FirstOrDefault(a => a.StartsWith("-a="));
-
-            var attibuteBullet = noAttributesOption != null ? (string) null
-                : (String.IsNullOrEmpty(attributeOption) ? "+" : attributeOption.Substring(3));
-
-            var text = File.ReadAllText(filePath);
-
-            var asBullets = new XmlConverter(attibuteBullet).Convert(text);
-
-            File.WriteAllText(fileOutPath, asBullets);
+            File.WriteAllText(appArgs.OutPath, asBullets);
         }
     }
 }

--- a/XmlToBullet/XmlToBullet.csproj
+++ b/XmlToBullet/XmlToBullet.csproj
@@ -48,10 +48,6 @@
     <Compile Include="XmlConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/XmlToBullet/XmlToBullet.csproj
+++ b/XmlToBullet/XmlToBullet.csproj
@@ -42,11 +42,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppArguments.cs" />
     <Compile Include="ConsoleApp.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="XmlConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Moved argument processing out to own class with tests.
Order of switches not important now which allows there to be no output specified.
When no output specified, prints to screen.
